### PR TITLE
fix: add missing imports and fix ngModel syntax

### DIFF
--- a/_posts/2023-08-26-Ionic7Angular-SQLite-CRUD-App.md
+++ b/_posts/2023-08-26-Ionic7Angular-SQLite-CRUD-App.md
@@ -332,6 +332,9 @@ Go to [Part 2 - Native - Table of Contents](#part-2---native---table-of-contents
         import { SQLiteService } from './app/services/sqlite.service';
         import { StorageService } from './app/services/storage.service';
         import { DbnameVersionService } from './app/services/dbname-version.service';
+   
+        import { defineCustomElements as pwaElements} from '@ionic/pwa-elements/loader';
+        import { defineCustomElements as jeepSqlite} from 'jeep-sqlite/loader';
 
         if (environment.production) {
             enableProdMode();
@@ -560,13 +563,13 @@ Go to [Part 2 - Native - Table of Contents](#part-2---native---table-of-contents
         <ion-checkbox
         aria-label="Label"
         slot="start"
-        ngModel="user.active"
+        [ngModel]="user.active"
         (ionChange)="updateUser(user)" >
         </ion-checkbox>
 
-        <ion-label>
+        <span>
         {{ user.id }} - {{ user.name }} - {{ user.active }}
-        </ion-label>
+        </span>
 
         <ion-button slot="end" (click)="deleteUser(user)" fill="clear" color="danger">
         <ion-icon name="trash" slot="icon-only"></ion-icon>


### PR DESCRIPTION
So, i noticed some flaws or improvements to be made. The first thing i did was adding missing imports. Otherwise the method `pwaElements()` and `jeepSqlite()` and `jeepEl.autoSave` would be marked as unknown.

Second, the ngModel attribute was missing the actual property binding. Which would result in the checkbox always be visibly checked, even though the `active` field of the user is switched correctly.

While at it, i replaced the `<ion-label>` by simple span elements. Otherwise you would get some warnings in the browser console. It's not that bad, but no warnings are better than some, i guess?

I did not update line 5. As i assume you would push a commit on your own to this PR in case you want to merge it, and update that line yourself? I did not intend to put my name on your blog, unless you want me to.